### PR TITLE
Ampersand characters in statuses displayed escaped

### DIFF
--- a/qataki
+++ b/qataki
@@ -541,6 +541,7 @@ fn_format() {
 	  s/\(@[$chars][$chars]*\)/$col_reply\1$col_normal/g;\
 	  s/\(#[$chars][$chars]*\)/$col_hash\1$col_normal/g;\
 	  s/\(![$chars][$chars]*\)/$col_group\1$col_normal/g;\
+          s/&amp;/\&/g;\
 	  s/\({context}\)$/[1m\1[0m/"
 }
 


### PR DESCRIPTION
https://twitter.com/bengoldacre/status/216549869769330688 was displayed in the output of

``` bash
./qataki t
```

as

```
   24. bengoldacre: RT @sciencegoddess: Did everyone see @sciam article by @DrBondar &amp;myself about
       #sciencegirlthing yesterday http://t.co/v4uNuA9i
```

instead of, as it should have been:

```
   24. bengoldacre: RT @sciencegoddess: Did everyone see @sciam article by @DrBondar &myself about
       #sciencegirlthing yesterday http://t.co/v4uNuA9i
```
